### PR TITLE
added a function to find compile_commands.json in build dir

### DIFF
--- a/lua/ros-nvim/init.lua
+++ b/lua/ros-nvim/init.lua
@@ -43,16 +43,37 @@ function M.setup(config)
     end
 end
 
-function M.get_compile_db_path()
-  local name = package.get_current_package_name()
-  if name ~= nil then
-    -- return "/home/davide/catkin_ws/build/" .. name
-    -- table.insert(clang_cmd, "--compile-commands-dir=".. "/home/davide/catkin_ws/build/" .. name)
-    -- return clang_cmd
-    return "--compile-commands-dir=".. "/home/davide/catkin_ws/build/" .. name
+-- returns true if open succeeds, so it exists
+function M.file_exists(name)
+  local f=io.open(name,"r")
+  if f~=nil then
+    io.close(f)
+    return true
+  else
+    return false
   end
 end
 
+-- notification is file is not found
+local no_file = "compile_commands.json does not exist in build dir"
+local not_package = "not in a ROS package"
+
+function M.get_clangd_arg()
+  local name = package.get_current_package_name()
+
+  if name ~= nil then
+    local db_path = "/home/davide/catkin_ws/build/" .. name
+    local db_file = "/home/davide/catkin_ws/build/" .. name .. "/compile_commands.json"
+    -- check if file exists but then pass path
+    if M.file_exists(db_file) then
+      return "--compile-commands-dir=".. db_path
+    else
+      vim.notify(no_file, "warn")
+    end
+  else
+    vim.notify(not_package, "warn")
+  end
+end
 -- local ros_nvim = vim.api.nvim_create_augroup("ros-nvim", {clear = true})
 -- vim.api.nvim_create_autocmd({"BufEnter"}, {pattern="*.cpp,*.cc", callback=cursorline, group = ros_nvim})
 

--- a/lua/ros-nvim/init.lua
+++ b/lua/ros-nvim/init.lua
@@ -45,12 +45,15 @@ end
 
 function M.get_compile_db_path()
   local name = package.get_current_package_name()
-  if name == nil then
-    return nil
-  else
-    return "/home/davide/catkin_ws/build/" .. name .. "/compile_commands.json"
+  if name ~= nil then
+    -- return "/home/davide/catkin_ws/build/" .. name
+    -- table.insert(clang_cmd, "--compile-commands-dir=".. "/home/davide/catkin_ws/build/" .. name)
+    -- return clang_cmd
+    return "--compile-commands-dir=".. "/home/davide/catkin_ws/build/" .. name
   end
-
 end
+
+-- local ros_nvim = vim.api.nvim_create_augroup("ros-nvim", {clear = true})
+-- vim.api.nvim_create_autocmd({"BufEnter"}, {pattern="*.cpp,*.cc", callback=cursorline, group = ros_nvim})
 
 return M

--- a/lua/ros-nvim/init.lua
+++ b/lua/ros-nvim/init.lua
@@ -1,6 +1,6 @@
 local vim_utils = require "ros-nvim.vim-utils"
 local action_state = require "telescope.actions.state"
-
+local package = require"ros-nvim.package"
 local M = {}
 
 ROS_CONFIG = {
@@ -41,6 +41,16 @@ function M.setup(config)
             ROS_CONFIG[key] = value
         end
     end
+end
+
+function M.get_compile_db_path()
+  local name = package.get_current_package_name()
+  if name == nil then
+    return nil
+  else
+    return "/home/davide/catkin_ws/build/" .. name .. "/compile_commands.json"
+  end
+
 end
 
 return M

--- a/lua/ros-nvim/init.lua
+++ b/lua/ros-nvim/init.lua
@@ -74,7 +74,8 @@ local not_package = "not in a ROS package"
 function M.get_clangd_arg()
   local name = package.get_current_package_name()
 
-  if name ~= nil then
+  -- name is not nil also when rospkg python is not found
+  if name ~= nil or name ~= 'no_ros_on_system' then
     local db_path = "/home/davide/catkin_ws/build/" .. name
     local db_file = "/home/davide/catkin_ws/build/" .. name .. "/compile_commands.json"
     -- check if file exists but then pass path

--- a/lua/ros-nvim/init.lua
+++ b/lua/ros-nvim/init.lua
@@ -54,6 +54,19 @@ function M.file_exists(name)
   end
 end
 
+-- local in_ros = false
+--
+-- local function ros_package()
+--   if package.get_current_package_name() == nil then
+--     in_ros = false
+--   else
+--     in_ros = true
+--   end
+-- end
+
+-- local ros_nvim = vim.api.nvim_create_augroup("ros-nvim", {clear = true})
+-- vim.api.nvim_create_autocmd({"BufEnter"}, {pattern="*.cpp,*.cc", callback=ros_package(), group = ros_nvim})
+
 -- notification is file is not found
 local no_file = "compile_commands.json does not exist in build dir"
 local not_package = "not in a ROS package"
@@ -74,7 +87,6 @@ function M.get_clangd_arg()
     vim.notify(not_package, "warn")
   end
 end
--- local ros_nvim = vim.api.nvim_create_augroup("ros-nvim", {clear = true})
--- vim.api.nvim_create_autocmd({"BufEnter"}, {pattern="*.cpp,*.cc", callback=cursorline, group = ros_nvim})
+
 
 return M

--- a/lua/ros-nvim/package.lua
+++ b/lua/ros-nvim/package.lua
@@ -2,7 +2,12 @@ local M = {}
 
 function M.get_current_package_name(path)
     path = path or vim.fn.expand("%:p")
-    local pkg_name = vim.fn.system('python3 -c "import rospkg;print(rospkg.get_package_name(\'' .. path .. '\'))"')
+    local pkg_name = vim.fn.system(
+    [[python3 -c "try: import rospkg; print(rospkg.get_package_name(pwd))
+except: print('no_ros_on_system')"
+    ]])
+
+    print(pkg_name)
     -- clean up output
     pkg_name, _ = string.gsub(pkg_name, "\r", "")
     pkg_name, _ = string.gsub(pkg_name, "\n", "")


### PR DESCRIPTION
As discussed in another issue I tried to write a function that allows to automatically pass `compile_commands.json` path as an argmument to `clangd` through lspconfig as follows:

```
local ros = require('ros-nvim')

lspconfig.clangd.setup{
  on_attach = on_attach,
  capabilities = capabilities,

  filetypes = {"c", "cpp"},
  -- cmd = cmd,
  cmd = {"clangd",
    -- "--compile-commands-dir='build'",
    "--suggest-missing-includes",
    "--clang-tidy",
    "--header-insertion=iwyu",
    "--all-scopes-completion",
    "--completion-style=detailed",
    ros.get_compile_db_path(),
    },
```

so by simply adding a call to the function that simply returns nil if that package name is not found.
For now it works, with some work to be done in terms of handling the not found case and generalising the path.